### PR TITLE
Accept header negotiation

### DIFF
--- a/acceptHeader.go
+++ b/acceptHeader.go
@@ -1,0 +1,74 @@
+package negotiator
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Accept is an http accept
+type Accept struct {
+	Header string
+}
+
+// WeightedValue is a value and associate weight between 0.0 and 1.0
+type WeightedValue struct {
+	Value  string
+	Weight float64
+}
+
+// ByWeight implements sort.Interface for []WeightedValue based
+//on the Weight field
+type ByWeight []WeightedValue
+
+func (a ByWeight) Len() int           { return len(a) }
+func (a ByWeight) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByWeight) Less(i, j int) bool { return a[i].Weight > a[j].Weight }
+
+// MediaRanges returns prioritized media ranges
+func (accept *Accept) MediaRanges() []WeightedValue {
+	var retVals []WeightedValue
+	mrs := strings.Split(accept.Header, ",")
+
+	for _, mr := range mrs {
+		mrAndAcceptParam := strings.Split(mr, ";")
+		//if no quality assigned then give 1.0
+		if len(mrAndAcceptParam) == 1 {
+			wv := new(WeightedValue)
+			wv.Value = strings.TrimSpace(mrAndAcceptParam[0])
+			wv.Weight = 1.0
+			retVals = append(retVals, *wv)
+			continue
+		}
+
+		wv := new(WeightedValue)
+		wv.Value = strings.TrimSpace(mrAndAcceptParam[0])
+
+		var weight float64
+		var err error
+		for index := 1; index < len(mrAndAcceptParam); index++ {
+			if strings.Contains(mrAndAcceptParam[index], "q=") {
+				weight, err = strconv.ParseFloat(strings.SplitAfter(mrAndAcceptParam[index], "q=")[1], 64)
+				if err != nil {
+					weight = 1.0
+				}
+			} else {
+				wv.Value = strings.Join([]string{wv.Value, mrAndAcceptParam[index]}, ";")
+			}
+
+		}
+
+		wv.Weight = weight
+		retVals = append(retVals, *wv)
+	}
+
+	//If no Accept header field is present, then it is assumed that the client
+	//accepts all media types. If an Accept header field is present, and if the
+	//server cannot send a response which is acceptable according to the combined
+	//Accept field value, then the server SHOULD send a 406 (not acceptable)
+	//response.
+
+	sort.Sort(ByWeight(retVals))
+
+	return retVals
+}

--- a/acceptHeader.go
+++ b/acceptHeader.go
@@ -11,22 +11,8 @@ type Accept struct {
 	Header string
 }
 
-// WeightedValue is a value and associate weight between 0.0 and 1.0
-type WeightedValue struct {
-	Value  string
-	Weight float64
-}
-
-// ByWeight implements sort.Interface for []WeightedValue based
-//on the Weight field
-type ByWeight []WeightedValue
-
-func (a ByWeight) Len() int           { return len(a) }
-func (a ByWeight) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByWeight) Less(i, j int) bool { return a[i].Weight > a[j].Weight }
-
 // MediaRanges returns prioritized media ranges
-func (accept *Accept) MediaRanges() []WeightedValue {
+func (accept *Accept) ParseMediaRanges() []WeightedValue {
 	var retVals []WeightedValue
 	mrs := strings.Split(accept.Header, ",")
 

--- a/acceptHeader_test.go
+++ b/acceptHeader_test.go
@@ -6,89 +6,77 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMediaRanges_parses_single(t *testing.T) {
+func TestParseMediaRanges_parses_single(t *testing.T) {
 	a := new(Accept)
 	a.Header = "application/json"
-	retVal := a.MediaRanges()
+	mr := a.ParseMediaRanges()
 
-	assert.Equal(t, 1, len(retVal))
-	assert.Equal(t, "application/json", retVal[0].Value)
-	assert.Equal(t, 1.0, retVal[0].Weight)
+	assert.Equal(t, 1, len(mr))
+	assert.Equal(t, "application/json", mr[0].Value)
+	assert.Equal(t, 1.0, mr[0].Weight)
 }
 
-func TestMediaRanges_defaults_quality_if_not_explicit(t *testing.T) {
+func TestParseMediaRanges_defaults_quality_if_not_explicit(t *testing.T) {
 	a := new(Accept)
 	a.Header = "text/plain"
-	mediaRanges := a.MediaRanges()
-	assert.Equal(t, 1, len(mediaRanges))
-	assert.Equal(t, 1.0, mediaRanges[0].Weight)
+	mr := a.ParseMediaRanges()
+	assert.Equal(t, 1, len(mr))
+	assert.Equal(t, 1.0, mr[0].Weight)
 }
 
-func TestMediaRanges_should_parse_quality(t *testing.T) {
+func TestParseMediaRanges_should_parse_quality(t *testing.T) {
 	a := new(Accept)
 	a.Header = "application/json;q=0.9"
-	retVal := a.MediaRanges()
+	mr := a.ParseMediaRanges()
 
-	assert.Equal(t, 1, len(retVal))
-	assert.Equal(t, "application/json", retVal[0].Value)
-	assert.Equal(t, 0.9, retVal[0].Weight)
+	assert.Equal(t, 1, len(mr))
+	assert.Equal(t, "application/json", mr[0].Value)
+	assert.Equal(t, 0.9, mr[0].Weight)
 }
 
-func TestMediaRanges_should_parse_multi_qualities(t *testing.T) {
+func TestParseMediaRanges_should_parse_multi_qualities(t *testing.T) {
 	a := new(Accept)
 	a.Header = "application/xml;q=1, application/json;q=0.9"
-	retVal := a.MediaRanges()
+	mr := a.ParseMediaRanges()
 
-	assert.Equal(t, 2, len(retVal))
+	assert.Equal(t, 2, len(mr))
 
-	assert.Equal(t, "application/xml", retVal[0].Value)
-	assert.Equal(t, 1.0, retVal[0].Weight)
+	assert.Equal(t, "application/xml", mr[0].Value)
+	assert.Equal(t, 1.0, mr[0].Weight)
 
-	assert.Equal(t, "application/json", retVal[1].Value)
-	assert.Equal(t, 0.9, retVal[1].Weight)
+	assert.Equal(t, "application/json", mr[1].Value)
+	assert.Equal(t, 0.9, mr[1].Weight)
 }
 
-func TestMediaRanges_orders_by_quality_decending(t *testing.T) {
+func TestParseMediaRanges_reorders_by_quality_decending(t *testing.T) {
 	a := new(Accept)
 	a.Header = "application/json;q=0.9, application/xml"
-	retVal := a.MediaRanges()
+	mr := a.ParseMediaRanges()
 
-	if len(retVal) != 2 {
-		t.Errorf("Wanted 2, Got %d", len(retVal))
-	}
+	assert.Equal(t, 2, len(mr))
 
-	if retVal[0].Value != "application/xml" {
-		t.Errorf("Wanted application/xml, Got %s", retVal[0].Value)
-	}
+	assert.Equal(t, "application/xml", mr[0].Value)
+	assert.Equal(t, 1.0, mr[0].Weight)
 
-	if retVal[0].Weight != 1.0 {
-		t.Errorf("Wanted 1.0, Got %d", retVal[0].Weight)
-	}
-
-	if retVal[1].Value != "application/json" {
-		t.Errorf("Wanted application/json, Got %s", retVal[1].Value)
-	}
-
-	if retVal[1].Weight != 0.9 {
-		t.Errorf("Wanted 0.9, Got %d", retVal[1].Weight)
-	}
+	assert.Equal(t, "application/json", mr[1].Value)
+	assert.Equal(t, 0.9, mr[1].Weight)
 }
 
 func TestMediaRanges_should_ignore_invalid_quality(t *testing.T) {
 	a := new(Accept)
 	a.Header = "text/html;q=blah"
-	ranges := a.MediaRanges()
+	mr := a.ParseMediaRanges()
 
-	assert.Equal(t, 1, len(ranges))
-	assert.Equal(t, "text/html", ranges[0].Value)
-	assert.Equal(t, 1.0, ranges[0].Weight)
+	assert.Equal(t, 1, len(mr))
+	assert.Equal(t, "text/html", mr[0].Value)
+	assert.Equal(t, 1.0, mr[0].Weight)
 }
 
 func TestMediaRanges_should_not_remove_accept_extension(t *testing.T) {
 	a := new(Accept)
 	a.Header = "text/html;q=0.5;a=1;b=2"
-	ranges := a.MediaRanges()
-	assert.Equal(t, 1, len(ranges))
-	assert.Equal(t, "text/html;a=1;b=2", ranges[0].Value)
-	assert.Equal(t, 0.5, ranges[0].Weight)
+	mr := a.ParseMediaRanges()
+	assert.Equal(t, 1, len(mr))
+	assert.Equal(t, "text/html;a=1;b=2", mr[0].Value)
+	assert.Equal(t, 0.5, mr[0].Weight)
 }

--- a/acceptHeader_test.go
+++ b/acceptHeader_test.go
@@ -1,0 +1,94 @@
+package negotiator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMediaRanges_parses_single(t *testing.T) {
+	a := new(Accept)
+	a.Header = "application/json"
+	retVal := a.MediaRanges()
+
+	assert.Equal(t, 1, len(retVal))
+	assert.Equal(t, "application/json", retVal[0].Value)
+	assert.Equal(t, 1.0, retVal[0].Weight)
+}
+
+func TestMediaRanges_defaults_quality_if_not_explicit(t *testing.T) {
+	a := new(Accept)
+	a.Header = "text/plain"
+	mediaRanges := a.MediaRanges()
+	assert.Equal(t, 1, len(mediaRanges))
+	assert.Equal(t, 1.0, mediaRanges[0].Weight)
+}
+
+func TestMediaRanges_should_parse_quality(t *testing.T) {
+	a := new(Accept)
+	a.Header = "application/json;q=0.9"
+	retVal := a.MediaRanges()
+
+	assert.Equal(t, 1, len(retVal))
+	assert.Equal(t, "application/json", retVal[0].Value)
+	assert.Equal(t, 0.9, retVal[0].Weight)
+}
+
+func TestMediaRanges_should_parse_multi_qualities(t *testing.T) {
+	a := new(Accept)
+	a.Header = "application/xml;q=1, application/json;q=0.9"
+	retVal := a.MediaRanges()
+
+	assert.Equal(t, 2, len(retVal))
+
+	assert.Equal(t, "application/xml", retVal[0].Value)
+	assert.Equal(t, 1.0, retVal[0].Weight)
+
+	assert.Equal(t, "application/json", retVal[1].Value)
+	assert.Equal(t, 0.9, retVal[1].Weight)
+}
+
+func TestMediaRanges_orders_by_quality_decending(t *testing.T) {
+	a := new(Accept)
+	a.Header = "application/json;q=0.9, application/xml"
+	retVal := a.MediaRanges()
+
+	if len(retVal) != 2 {
+		t.Errorf("Wanted 2, Got %d", len(retVal))
+	}
+
+	if retVal[0].Value != "application/xml" {
+		t.Errorf("Wanted application/xml, Got %s", retVal[0].Value)
+	}
+
+	if retVal[0].Weight != 1.0 {
+		t.Errorf("Wanted 1.0, Got %d", retVal[0].Weight)
+	}
+
+	if retVal[1].Value != "application/json" {
+		t.Errorf("Wanted application/json, Got %s", retVal[1].Value)
+	}
+
+	if retVal[1].Weight != 0.9 {
+		t.Errorf("Wanted 0.9, Got %d", retVal[1].Weight)
+	}
+}
+
+func TestMediaRanges_should_ignore_invalid_quality(t *testing.T) {
+	a := new(Accept)
+	a.Header = "text/html;q=blah"
+	ranges := a.MediaRanges()
+
+	assert.Equal(t, 1, len(ranges))
+	assert.Equal(t, "text/html", ranges[0].Value)
+	assert.Equal(t, 1.0, ranges[0].Weight)
+}
+
+func TestMediaRanges_should_not_remove_accept_extension(t *testing.T) {
+	a := new(Accept)
+	a.Header = "text/html;q=0.5;a=1;b=2"
+	ranges := a.MediaRanges()
+	assert.Equal(t, 1, len(ranges))
+	assert.Equal(t, "text/html;a=1;b=2", ranges[0].Value)
+	assert.Equal(t, 0.5, ranges[0].Weight)
+}

--- a/negotiate.go
+++ b/negotiate.go
@@ -27,7 +27,7 @@ func Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
 	//TODO:test should not be case sensitive
 	accept.Header = req.Header.Get("Accept")
 
-	for _, mr := range accept.MediaRanges() {
+	for _, mr := range accept.ParseMediaRanges() {
 		for _, processor := range processors {
 			if processor.CanProcess(mr.Value) {
 				processor.Process(w, model)

--- a/weightedValue.go
+++ b/weightedValue.go
@@ -1,0 +1,15 @@
+package negotiator
+
+// WeightedValue is a value and associate weight between 0.0 and 1.0
+type WeightedValue struct {
+	Value  string
+	Weight float64
+}
+
+// ByWeight implements sort.Interface for []WeightedValue based
+//on the Weight field. The data will be returned sorted decending
+type ByWeight []WeightedValue
+
+func (a ByWeight) Len() int           { return len(a) }
+func (a ByWeight) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByWeight) Less(i, j int) bool { return a[i].Weight > a[j].Weight }


### PR DESCRIPTION
Adds initial implementation of Accept header parsing and prioritization. Based on http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
