### PR TITLE
WIP Remove global state

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/jchannon/negotiator"
+)
+
+func main() {
+	http.HandleFunc("/", homeHandler)
+	http.ListenAndServe(":9001", nil)
+}
+
+func homeHandler(w http.ResponseWriter, req *http.Request) {
+	user := &user{"Joe", "Bloggs"}
+	negotiator.Negotiate(w, req, user)
+}
+
+type user struct {
+	Firstname string
+	Lastname  string
+}

--- a/demo/main.go
+++ b/demo/main.go
@@ -4,16 +4,26 @@ import (
 	"net/http"
 
 	"github.com/jchannon/negotiator"
+	"github.com/jchannon/negotiator/demo/responseprocessors"
 )
 
 func main() {
+
 	http.HandleFunc("/", homeHandler)
+	http.HandleFunc("/custom", customHandler)
 	http.ListenAndServe(":9001", nil)
 }
 
 func homeHandler(w http.ResponseWriter, req *http.Request) {
 	user := &user{"Joe", "Bloggs"}
 	negotiator.Negotiate(w, req, user)
+}
+
+func customHandler(w http.ResponseWriter, req *http.Request) {
+	user := &user{"Joe", "Bloggs"}
+	//Creating the negotiator could be put in middleware so you don't have to do this in every handler
+	textplainNegotiator := negotiator.New(&responseprocessors.PlainTextResponseProcessor{})
+	textplainNegotiator.Negotiate(w, req, user)
 }
 
 type user struct {

--- a/demo/responseprocessors/plaintextResponseProcessor.go
+++ b/demo/responseprocessors/plaintextResponseProcessor.go
@@ -1,0 +1,29 @@
+package responseprocessors
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+)
+
+type PlainTextResponseProcessor struct {
+}
+
+func (*PlainTextResponseProcessor) CanProcess(mediaRange string) bool {
+	return strings.EqualFold(mediaRange, "text/plain")
+}
+
+func (*PlainTextResponseProcessor) Process(w http.ResponseWriter, model interface{}) {
+
+	w.Header().Set("Content-Type", "text/plain")
+
+	val := reflect.ValueOf(model).Elem()
+
+	for i := 0; i < val.NumField(); i++ {
+		valueField := val.Field(i).String()
+		typeField := val.Type().Field(i)
+
+		w.Write([]byte(typeField.Name + " : " + valueField + " "))
+	}
+
+}

--- a/negotiate.go
+++ b/negotiate.go
@@ -23,12 +23,6 @@ func New(responseProcessors ...ResponseProcessor) *Negotiator {
 	}
 }
 
-//AddResponseProcessor allows you to add custom ResponseProcessors for your own content negotiation eg/PDF
-// func (n *Negotiator) AddResponseProcessor(responseProcessors ...ResponseProcessor) {
-// 	//ResponseProcessor is an interface and you shouldnt declare a pointer to an interface *ResponseProcessor
-// 	n.processors = append(responseProcessors, n.processors...)
-// }
-
 //Negotiate your model based on HTTP Accept header
 func (n *Negotiator) Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
 	negotiateHeader(n.processors, w, req, model)

--- a/negotiate.go
+++ b/negotiate.go
@@ -9,18 +9,31 @@
 //
 package negotiator
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+)
 
-var processors = []ResponseProcessor{&jsonProcessor{}, &xmlProcessor{}}
+//Negotiator is responsible for content negotiation
+type Negotiator struct{ processors []ResponseProcessor }
 
 //New sets up response processors. By default XML and JSON are created
-func New(responseProcessors ...ResponseProcessor) {
-	//ResponseProcessor is an interface and you shouldn't declare a pointer to an interface *ResponseProcessor
-	processors = append(responseProcessors, processors...)
+func New() *Negotiator {
+	processors := []ResponseProcessor{&jsonProcessor{}, &xmlProcessor{}}
+	return &Negotiator{
+		processors,
+	}
+}
+
+//AddResponseProcessor allows you to add custom ResponseProcessors for your own content negotiation eg/PDF
+func (n *Negotiator) AddResponseProcessor(responseProcessors ...ResponseProcessor) {
+	//ResponseProcessor is an interface and you shouldnt declare a pointer to an interface *ResponseProcessor
+	n.processors = append(responseProcessors, n.processors...)
 }
 
 //Negotiate your model based on HTTP Accept header
-func Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
+func (n *Negotiator) Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
 
 	accept := new(accept)
 

--- a/negotiate.go
+++ b/negotiate.go
@@ -9,11 +9,7 @@
 //
 package negotiator
 
-import (
-	"fmt"
-	"net/http"
-	"reflect"
-)
+import "net/http"
 
 //Negotiator is responsible for content negotiation
 type Negotiator struct{ processors []ResponseProcessor }
@@ -34,8 +30,17 @@ func (n *Negotiator) AddResponseProcessor(responseProcessors ...ResponseProcesso
 
 //Negotiate your model based on HTTP Accept header
 func (n *Negotiator) Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
+	negotiateHeader(n.processors, w, req, model)
+}
 
-	accept := new(accept)
+//Negotiate your model based on HTTP Accept header
+func Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
+	processors := []ResponseProcessor{&jsonProcessor{}, &xmlProcessor{}}
+	negotiateHeader(processors, w, req, model)
+}
+
+func negotiateHeader(processors []ResponseProcessor, w http.ResponseWriter, req *http.Request, model interface{}) {
+	accept := new(Accept)
 
 	accept.Header = req.Header.Get("Accept")
 

--- a/negotiate_test.go
+++ b/negotiate_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,13 +51,27 @@ func TestShouldReturn406IfNoAcceptHeaderWithoutCustomerResponseProcessor(t *test
 
 }
 
+func TestShouldNegotiateAndWriteToResponseBody(t *testing.T) {
+	var fakeResponseProcessor = &fakeProcessor{}
+	negotiator := New(fakeResponseProcessor)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Add("Accept", "application/negotiatortesting")
+	recorder := httptest.NewRecorder()
+
+	negotiator.Negotiate(recorder, req, nil)
+
+	assert.Equal(t, "boo ya!", recorder.Body.String())
+
+}
+
 type fakeProcessor struct {
 }
 
 func (*fakeProcessor) CanProcess(mediaRange string) bool {
-	return true
+	return strings.EqualFold(mediaRange, "application/negotiatortesting")
 }
 
 func (*fakeProcessor) Process(w http.ResponseWriter, model interface{}) {
-
+	w.Write([]byte("boo ya!"))
 }

--- a/negotiate_test.go
+++ b/negotiate_test.go
@@ -3,39 +3,53 @@ package negotiator
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// func TestShouldAddCustomResponseProcessors(t *testing.T) {
-//
-// 	var fakeResponseProcessor = &fakeProcessor{}
-//
-// 	New(fakeResponseProcessor)
-//
-// 	assert.Equal(t, 3, len(processors))
-// }
-//
-// func TestShouldAddCustomResponseProcessorsToBeginning(t *testing.T) {
-//
-// 	var fakeResponseProcessor = &fakeProcessor{}
-//
-// 	New(fakeResponseProcessor)
-//
-// 	firstProcessor := processors[0]
-// 	processorName := reflect.TypeOf(firstProcessor).String()
-//
-// 	assert.Equal(t, "*negotiator.fakeProcessor", processorName)
-// }
+func TestShouldAddCustomResponseProcessors(t *testing.T) {
+
+	negotiator := New()
+	var fakeResponseProcessor = &fakeProcessor{}
+
+	negotiator.AddResponseProcessor(fakeResponseProcessor)
+
+	assert.Equal(t, 3, len(negotiator.processors))
+}
+
+func TestShouldAddCustomResponseProcessorsToBeginning(t *testing.T) {
+
+	negotiator := New()
+	var fakeResponseProcessor = &fakeProcessor{}
+
+	negotiator.AddResponseProcessor(fakeResponseProcessor)
+
+	firstProcessor := negotiator.processors[0]
+	processorName := reflect.TypeOf(firstProcessor).String()
+
+	assert.Equal(t, "*negotiator.fakeProcessor", processorName)
+}
 
 func TestShouldReturn406IfNoAcceptHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
+
+	negotiator := New()
+	negotiator.Negotiate(recorder, req, nil)
+
+	assert.Equal(t, 406, recorder.Code)
+}
+
+func TestShouldReturn406IfNoAcceptHeaderWithoutCustomerResponseProcessor(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	recorder := httptest.NewRecorder()
 
 	Negotiate(recorder, req, nil)
 
 	assert.Equal(t, 406, recorder.Code)
+
 }
 
 type fakeProcessor struct {

--- a/negotiate_test.go
+++ b/negotiate_test.go
@@ -2,31 +2,40 @@ package negotiator
 
 import (
 	"net/http"
-	"reflect"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestShouldAddCustomResponseProcessors(t *testing.T) {
+// func TestShouldAddCustomResponseProcessors(t *testing.T) {
+//
+// 	var fakeResponseProcessor = &fakeProcessor{}
+//
+// 	New(fakeResponseProcessor)
+//
+// 	assert.Equal(t, 3, len(processors))
+// }
+//
+// func TestShouldAddCustomResponseProcessorsToBeginning(t *testing.T) {
+//
+// 	var fakeResponseProcessor = &fakeProcessor{}
+//
+// 	New(fakeResponseProcessor)
+//
+// 	firstProcessor := processors[0]
+// 	processorName := reflect.TypeOf(firstProcessor).String()
+//
+// 	assert.Equal(t, "*negotiator.fakeProcessor", processorName)
+// }
 
-	var fakeResponseProcessor = &fakeProcessor{}
+func TestShouldReturn406IfNoAcceptHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
 
-	New(fakeResponseProcessor)
+	Negotiate(recorder, req, nil)
 
-	assert.Equal(t, 3, len(processors))
-}
-
-func TestShouldAddCustomResponseProcessorsToBeginning(t *testing.T) {
-
-	var fakeResponseProcessor = &fakeProcessor{}
-
-	New(fakeResponseProcessor)
-
-	firstProcessor := processors[0]
-	processorName := reflect.TypeOf(firstProcessor).String()
-
-	assert.Equal(t, "*negotiator.fakeProcessor", processorName)
+	assert.Equal(t, 406, recorder.Code)
 }
 
 type fakeProcessor struct {

--- a/negotiate_test.go
+++ b/negotiate_test.go
@@ -11,20 +11,16 @@ import (
 
 func TestShouldAddCustomResponseProcessors(t *testing.T) {
 
-	negotiator := New()
 	var fakeResponseProcessor = &fakeProcessor{}
-
-	negotiator.AddResponseProcessor(fakeResponseProcessor)
+	negotiator := New(fakeResponseProcessor)
 
 	assert.Equal(t, 3, len(negotiator.processors))
 }
 
 func TestShouldAddCustomResponseProcessorsToBeginning(t *testing.T) {
 
-	negotiator := New()
 	var fakeResponseProcessor = &fakeProcessor{}
-
-	negotiator.AddResponseProcessor(fakeResponseProcessor)
+	negotiator := New(fakeResponseProcessor)
 
 	firstProcessor := negotiator.processors[0]
 	processorName := reflect.TypeOf(firstProcessor).String()
@@ -33,10 +29,12 @@ func TestShouldAddCustomResponseProcessorsToBeginning(t *testing.T) {
 }
 
 func TestShouldReturn406IfNoAcceptHeader(t *testing.T) {
+	var fakeResponseProcessor = &fakeProcessor{}
+	negotiator := New(fakeResponseProcessor)
+
 	req, _ := http.NewRequest("GET", "/", nil)
 	recorder := httptest.NewRecorder()
 
-	negotiator := New()
 	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, 406, recorder.Code)


### PR DESCRIPTION
After writing some tests I found out the `var processors = []ResponseProcessor{&jsonProcessor{}, &xmlProcessor{}}` is global so when each test was run and it added a custom processor, by the time it hit my new test there were 4 processors. 

Obviously we dont want global state however, this makes the API not as succinct when users want to add custom processors. They will have to call `New` then `AddResponseProcessors` then `Negotiate` in the htp handler, one option is to put the first 2 calls in some middleware which would tidy it up.  I've kept the same API ie/just calling Negotiate from the handler if you dont want to add a custom processor so thats something I guess.

Thoughts??
