### PR TITLE
Move errorHandler func under Negotiator struct

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -21,26 +21,27 @@ func main() {
 
 func homeHandler(w http.ResponseWriter, req *http.Request) {
 	user := &user{"Joe", "Bloggs"}
-	negotiator.Negotiate(w,req,user,errorhandlers.GlobalErrorHandler)
+	negotiator.Negotiate(w, req, user, errorhandlers.GlobalErrorHandler)
 }
 
 func customHandler(w http.ResponseWriter, req *http.Request) {
 	user := &user{"Joe", "Bloggs"}
 	//Creating the negotiator could be done for only required handlers or use middleware for all
 	textplainNegotiator := negotiator.New(&responseprocessors.PlainTextResponseProcessor{})
-	textplainNegotiator.Negotiate(w, req, user, errorhandlers.GlobalErrorHandler)
+	textplainNegotiator.ErrorHandler = errorhandlers.GlobalErrorHandler
+	textplainNegotiator.Negotiate(w, req, user)
 }
 
 func multiNegotiatorHandler(c web.C, w http.ResponseWriter, req *http.Request) {
 	user := &user{"Joe", "Bloggs"}
 	mynegotiator := c.Env["negotiator"].(*negotiator.Negotiator)
-	mynegotiator.Negotiate(w, req, user,errorhandlers.GlobalErrorHandler)
+	mynegotiator.Negotiate(w, req, user)
 }
 
 func multiNegotiatorHandlerAgain(c web.C, w http.ResponseWriter, req *http.Request) {
 	user := &user{"John", "Doe"}
 	mynegotiator := c.Env["negotiator"].(*negotiator.Negotiator)
-	mynegotiator.Negotiate(w, req, user,errorhandlers.GlobalErrorHandler)
+	mynegotiator.Negotiate(w, req, user)
 }
 
 type user struct {
@@ -50,7 +51,9 @@ type user struct {
 
 func negotiatormw(c *web.C, h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		c.Env["negotiator"] = negotiator.New(&responseprocessors.PlainTextResponseProcessor{})
+		n := negotiator.New(&responseprocessors.PlainTextResponseProcessor{})
+		n.ErrorHandler = errorhandlers.GlobalErrorHandler
+		c.Env["negotiator"] = n
 
 		h.ServeHTTP(w, r)
 	}

--- a/negotiate.go
+++ b/negotiate.go
@@ -15,20 +15,23 @@ import (
 )
 
 //Negotiator is responsible for content negotiation when using custom response processors
-type Negotiator struct{ processors []ResponseProcessor }
+type Negotiator struct {
+	processors   []ResponseProcessor
+	ErrorHandler func(w http.ResponseWriter, err error)
+}
 
 //New allows users to pass custom response processors. By default XML and JSON are already created
 func New(responseProcessors ...ResponseProcessor) *Negotiator {
 	processors := []ResponseProcessor{&jsonProcessor{}, &xmlProcessor{}}
 	processors = append(responseProcessors, processors...)
 	return &Negotiator{
-		processors,
+		processors: processors,
 	}
 }
 
 //Negotiate your model based on HTTP Accept header
-func (n *Negotiator) Negotiate(w http.ResponseWriter, req *http.Request, model interface{}, errorHandler func(w http.ResponseWriter, err error)) {
-	negotiateHeader(n.processors, w, req, model, errorHandler)
+func (n *Negotiator) Negotiate(w http.ResponseWriter, req *http.Request, model interface{}) {
+	negotiateHeader(n.processors, w, req, model, n.ErrorHandler)
 }
 
 //Negotiate your model based on HTTP Accept header. By default XML and JSON are handled

--- a/negotiate_test.go
+++ b/negotiate_test.go
@@ -36,7 +36,7 @@ func TestShouldReturn406IfNoAcceptHeader(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	recorder := httptest.NewRecorder()
 
-	negotiator.Negotiate(recorder, req, nil, nil)
+	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, http.StatusNotAcceptable, recorder.Code)
 }
@@ -59,7 +59,7 @@ func TestShouldNegotiateAndWriteToResponseBody(t *testing.T) {
 	req.Header.Add("Accept", "application/negotiatortesting")
 	recorder := httptest.NewRecorder()
 
-	negotiator.Negotiate(recorder, req, nil, nil)
+	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, "boo ya!", recorder.Body.String())
 
@@ -73,7 +73,7 @@ func TestShouldNegotiateADefaultProcessor(t *testing.T) {
 	req.Header.Add("Accept", "*/*")
 	recorder := httptest.NewRecorder()
 
-	negotiator.Negotiate(recorder, req, nil, nil)
+	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, "boo ya!", recorder.Body.String())
 }


### PR DESCRIPTION
I have moved the ErrorHandler under Negotiator to provide a global configuration point for this option. Have a look at the provided demos for further information and examples. 
