### PR TITLE
Return error from ResponseProcessor

### DIFF
--- a/demo/main.go
+++ b/demo/main.go
@@ -7,40 +7,39 @@ import (
 	"github.com/jchannon/negotiator/demo/responseprocessors"
 	"github.com/zenazn/goji"
 	"github.com/zenazn/goji/web"
-	"github.com/jchannon/negotiator/demo/errorhandlers"
 )
 
 func main() {
 	goji.Use(negotiatormw)
-	goji.Get("/", homeHandler)
-	goji.Get("/oneoffnegotiator", customHandler)
-	goji.Get("/multinegotiator", multiNegotiatorHandler)
-	goji.Get("/multinegotiatoragain", multiNegotiatorHandlerAgain)
+	goji.Get("/", appHandler(homeHandler))
+	goji.Get("/oneoffnegotiator", appHandler(customHandler))
+	goji.Get("/multinegotiator", appHandler(multiNegotiatorHandler))
+	goji.Get("/multinegotiatoragain", appHandler(multiNegotiatorHandlerAgain))
 	goji.Serve()
 }
 
-func homeHandler(w http.ResponseWriter, req *http.Request) {
+func homeHandler(c web.C, w http.ResponseWriter, req *http.Request) error {
 	user := &user{"Joe", "Bloggs"}
-	negotiator.Negotiate(w,req,user,errorhandlers.GlobalErrorHandler)
+	return negotiator.Negotiate(w, req, user)
 }
 
-func customHandler(w http.ResponseWriter, req *http.Request) {
+func customHandler(c web.C, w http.ResponseWriter, req *http.Request) error {
 	user := &user{"Joe", "Bloggs"}
 	//Creating the negotiator could be done for only required handlers or use middleware for all
 	textplainNegotiator := negotiator.New(&responseprocessors.PlainTextResponseProcessor{})
-	textplainNegotiator.Negotiate(w, req, user, errorhandlers.GlobalErrorHandler)
+	return textplainNegotiator.Negotiate(w, req, user)
 }
 
-func multiNegotiatorHandler(c web.C, w http.ResponseWriter, req *http.Request) {
+func multiNegotiatorHandler(c web.C, w http.ResponseWriter, req *http.Request) error {
 	user := &user{"Joe", "Bloggs"}
 	mynegotiator := c.Env["negotiator"].(*negotiator.Negotiator)
-	mynegotiator.Negotiate(w, req, user,errorhandlers.GlobalErrorHandler)
+	return mynegotiator.Negotiate(w, req, user)
 }
 
-func multiNegotiatorHandlerAgain(c web.C, w http.ResponseWriter, req *http.Request) {
+func multiNegotiatorHandlerAgain(c web.C, w http.ResponseWriter, req *http.Request) error {
 	user := &user{"John", "Doe"}
 	mynegotiator := c.Env["negotiator"].(*negotiator.Negotiator)
-	mynegotiator.Negotiate(w, req, user,errorhandlers.GlobalErrorHandler)
+	return mynegotiator.Negotiate(w, req, user)
 }
 
 type user struct {
@@ -55,4 +54,20 @@ func negotiatormw(c *web.C, h http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)
+}
+
+// Application error handler
+// Goji requires to implement both ServeHTTP and ServeHTTPC
+type appHandler func(web.C, http.ResponseWriter, *http.Request) error
+
+func (fn appHandler) ServeHTTP(c web.C, w http.ResponseWriter, r *http.Request) {
+	if err := fn(c, w, r); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (fn appHandler) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	if err := fn(c, w, r); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/demo/responseprocessors/plaintextResponseProcessor.go
+++ b/demo/responseprocessors/plaintextResponseProcessor.go
@@ -15,12 +15,11 @@ func (*PlainTextResponseProcessor) CanProcess(mediaRange string) bool {
 	return strings.EqualFold(mediaRange, "text/plain")
 }
 
-func (*PlainTextResponseProcessor) Process(w http.ResponseWriter, model interface{}, errorHandler func(w http.ResponseWriter, err error)) {
+func (*PlainTextResponseProcessor) Process(w http.ResponseWriter, model interface{}) error {
 
 	if currTime := time.Now(); currTime.Second()%2 == 0 {
 		err := errors.New("This is a sample error showcasing how to use a error handler with negotiator")
-		errorHandler(w, err)
-		return
+		return err
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
@@ -33,5 +32,7 @@ func (*PlainTextResponseProcessor) Process(w http.ResponseWriter, model interfac
 
 		w.Write([]byte(typeField.Name + " : " + valueField + " "))
 	}
+
+	return nil
 
 }

--- a/jsonprocessor.go
+++ b/jsonprocessor.go
@@ -15,15 +15,15 @@ func (*jsonProcessor) CanProcess(mediaRange string) bool {
 		strings.HasSuffix(mediaRange, "+json")
 }
 
-func (*jsonProcessor) Process(w http.ResponseWriter, model interface{}, errorHandler func(w http.ResponseWriter, err error)) {
+func (*jsonProcessor) Process(w http.ResponseWriter, model interface{}) error {
 	w.Header().Set("Content-Type", "application/json")
 
 	js, err := json.Marshal(model)
 
 	if err != nil {
-		errorHandler(w, err)
-		return
+		return err
 	}
 
-	w.Write(js)
+	_, err = w.Write(js)
+	return err
 }

--- a/jsonprocessor_test.go
+++ b/jsonprocessor_test.go
@@ -37,7 +37,7 @@ func TestShouldSetContentTypeHeader(t *testing.T) {
 
 	jsonProcessor := &jsonProcessor{}
 
-	jsonProcessor.Process(recorder, model, nil)
+	jsonProcessor.Process(recorder, model)
 
 	assert.Equal(t, "application/json", recorder.HeaderMap.Get("Content-Type"))
 }
@@ -53,12 +53,12 @@ func TestShouldSetResponseBody(t *testing.T) {
 
 	jsonProcessor := &jsonProcessor{}
 
-	jsonProcessor.Process(recorder, model, nil)
+	jsonProcessor.Process(recorder, model)
 
 	assert.Equal(t, "{\"Name\":\"Joe Bloggs\"}", recorder.Body.String())
 }
 
-func TestShouldCallErrorHandlerOnJsonError(t *testing.T) {
+func TestShouldReturnErrorOnJsonError(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	model := &User{
@@ -67,10 +67,9 @@ func TestShouldCallErrorHandlerOnJsonError(t *testing.T) {
 
 	jsonProcessor := &jsonProcessor{}
 
-	jsonProcessor.Process(recorder, model, jsontestErrorHandler)
+	err := jsonProcessor.Process(recorder, model)
 
-	assert.Equal(t, 500, recorder.Code)
-	assert.Equal(t, "json: error calling MarshalJSON for type *negotiator.User: oops", recorder.Body.String())
+	assert.Error(t, err)
 }
 
 type User struct {

--- a/negotiate_test.go
+++ b/negotiate_test.go
@@ -36,7 +36,7 @@ func TestShouldReturn406IfNoAcceptHeader(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	recorder := httptest.NewRecorder()
 
-	negotiator.Negotiate(recorder, req, nil, nil)
+	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, http.StatusNotAcceptable, recorder.Code)
 }
@@ -45,7 +45,7 @@ func TestShouldReturn406IfNoAcceptHeaderWithoutCustomResponseProcessor(t *testin
 	req, _ := http.NewRequest("GET", "/", nil)
 	recorder := httptest.NewRecorder()
 
-	Negotiate(recorder, req, nil, nil)
+	Negotiate(recorder, req, nil)
 
 	assert.Equal(t, http.StatusNotAcceptable, recorder.Code)
 
@@ -59,7 +59,7 @@ func TestShouldNegotiateAndWriteToResponseBody(t *testing.T) {
 	req.Header.Add("Accept", "application/negotiatortesting")
 	recorder := httptest.NewRecorder()
 
-	negotiator.Negotiate(recorder, req, nil, nil)
+	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, "boo ya!", recorder.Body.String())
 
@@ -73,7 +73,7 @@ func TestShouldNegotiateADefaultProcessor(t *testing.T) {
 	req.Header.Add("Accept", "*/*")
 	recorder := httptest.NewRecorder()
 
-	negotiator.Negotiate(recorder, req, nil, nil)
+	negotiator.Negotiate(recorder, req, nil)
 
 	assert.Equal(t, "boo ya!", recorder.Body.String())
 }
@@ -85,6 +85,7 @@ func (*fakeProcessor) CanProcess(mediaRange string) bool {
 	return strings.EqualFold(mediaRange, "application/negotiatortesting")
 }
 
-func (*fakeProcessor) Process(w http.ResponseWriter, model interface{}, errorHandler func(w http.ResponseWriter, err error)) {
+func (*fakeProcessor) Process(w http.ResponseWriter, model interface{}) error {
 	w.Write([]byte("boo ya!"))
+	return nil
 }

--- a/responseprocessor.go
+++ b/responseprocessor.go
@@ -5,5 +5,5 @@ import "net/http"
 //ResponseProcessor interface that creates contract for custom content negotiation
 type ResponseProcessor interface {
 	CanProcess(mediaRange string) bool
-	Process(w http.ResponseWriter, model interface{}, errorHandler func(w http.ResponseWriter, err error))
+	Process(w http.ResponseWriter, model interface{}) error
 }

--- a/xmlprocessor.go
+++ b/xmlprocessor.go
@@ -13,13 +13,13 @@ func (*xmlProcessor) CanProcess(mediaRange string) bool {
 	return strings.HasSuffix(mediaRange, "xml")
 }
 
-func (*xmlProcessor) Process(w http.ResponseWriter, model interface{}, errorHandler func(w http.ResponseWriter, err error)) {
+func (*xmlProcessor) Process(w http.ResponseWriter, model interface{}) error {
 	x, err := xml.MarshalIndent(model, "", "  ")
 	if err != nil {
-		errorHandler(w, err)
-		return
+		return err
 	}
 
 	w.Header().Set("Content-Type", "application/xml")
-	w.Write(x)
+	_, err = w.Write(x)
+	return err
 }

--- a/xmlprocessor_test.go
+++ b/xmlprocessor_test.go
@@ -34,7 +34,7 @@ func TestShouldSetXmlContentTypeHeader(t *testing.T) {
 
 	xmlProcessor := &xmlProcessor{}
 
-	xmlProcessor.Process(recorder, model, nil)
+	xmlProcessor.Process(recorder, model)
 
 	assert.Equal(t, "application/xml", recorder.HeaderMap.Get("Content-Type"))
 }
@@ -48,12 +48,12 @@ func TestShouldSetXmlResponseBody(t *testing.T) {
 
 	xmlProcessor := &xmlProcessor{}
 
-	xmlProcessor.Process(recorder, model, nil)
+	xmlProcessor.Process(recorder, model)
 
 	assert.Equal(t, "<ValidXMLUser>\n  <Name>Joe Bloggs</Name>\n</ValidXMLUser>", recorder.Body.String())
 }
 
-func TestShouldCallErrorHandlerOnXmlError(t *testing.T) {
+func TestShouldReturnErrorOnXmlError(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	model := &XMLUser{
@@ -62,9 +62,9 @@ func TestShouldCallErrorHandlerOnXmlError(t *testing.T) {
 
 	xmlProcessor := &xmlProcessor{}
 
-	xmlProcessor.Process(recorder, model, xmltestErrorHandler)
+	err := xmlProcessor.Process(recorder, model)
 
-	assert.Equal(t, 500, recorder.Code)
+	assert.Error(t, err)
 }
 
 type ValidXMLUser struct {


### PR DESCRIPTION
An alternative approach on error handling (as briefly suggested in #17)
- errorHandler is dropped; error is returned instead
- One less parameter for func Negotiate
- Errors occurred during content negotiation can be handled similar to any other application errors
- While func Negotiate returns only an error, handler may return (error), (int, error) or any other struct i.e. *appError (providing further flexibility) - see resources below
- Tests updated (Code coverage at 100%)
- Demo also updated to include appHandler

Further information:
- [Error Handling and Go](http://blog.golang.org/error-handling-and-go#TOC_3.)
- [Custom Handlers and Avoiding Globals in Go Web Applications](https://elithrar.github.io/article/custom-handlers-avoiding-globals/)
